### PR TITLE
Improve FreeDesktop integration

### DIFF
--- a/src/trackerboy.desktop
+++ b/src/trackerboy.desktop
@@ -1,7 +1,13 @@
 [Desktop Entry]
+Version=1.0
 Type=Application
 Name=Trackerboy
-Comment=Gameboy music tracker
+Comment=Game Boy music tracker
+Keywords=game;boy;gameboy;color;tracker
+Categories=Audio;AudioVideo;
 Exec=trackerboy
 Icon=trackerboy
-Categories=Audio;AudioVideo;
+Terminal=false
+StartupNotify=true
+StartupWMClass=trackerboy
+MimeType=application/x-trackerboy-module

--- a/src/trackerboy.xml
+++ b/src/trackerboy.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="application/x-trackerboy-module">
+    <comment>Trackerboy module</comment>
+    <icon name="x-trackerboy-module"/>
+    <glob pattern="*.tbm"/>
+    <magic>
+      <!-- 12-byte signature, defined in libtrackerboy's `fileformat.cpp`. -->
+      <match type="string" offset="0" value="\0TRACKERBOY\0"/>
+    </magic>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
These associate `.tbm` files with Trackerboy by default, out of the box, and also gives them Trackerboy's icon in file managers.