### PR TITLE
Added cli option for exporting to wav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+ - Command line WAV export: `trackerboy <module> --export-wav <output>`
+   exports a module without starting the editor. Use `--separate` to write
+   each channel to its own file, `--channels` to pick channels, and
+   `--loops`/`--duration`, `--samplerate` and `--song` to control playback.
+   See `trackerboy --help` for details.
+
 ## [0.6.6] - 2025-09-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ My tag is stoneface#7646 or you can join the server, https://discord.gg/m6wcAK3
  * __Contribute:__ For contributing to this repo, see the [contributing guidelines](CONTRIBUTING.md) and [source code organization](ORGANIZATION.md).
  * __Use:__ For details on how to use the tracker, see the [manual](https://www.trackerboy.org/manual).
 
+## Command line
+
+Trackerboy can also export a module to WAV from the command line, without
+starting the editor (no display is required):
+
+```sh
+# export the whole song to a single file
+trackerboy song.tbm --export-wav song.wav
+
+# export channels 1, 2 and 4, each to its own file: out/song.ch1.wav, out/song.ch2.wav, ...
+trackerboy song.tbm --export-wav out/ --separate --channels 1,2,4
+
+# play the second song of the module 3 times, at 48000 Hz
+trackerboy song.tbm --export-wav song.wav --song 2 --loops 3 --samplerate 48000
+
+# play for 1 minute and 30 seconds instead of looping
+trackerboy song.tbm --export-wav song.wav --duration 01:30
+```
+
+Run `trackerboy --help` for the full list of options.
+
 ## Status
 
 [v0.6.3](https://github.com/stoneface86/trackerboy/releases/tag/v0.6.3) is now available.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,7 @@ makeSourceList(UI_SRC
     "core/PatternSelection"
     "core/StandardRates"
 
+    "export/ExportWavCommand"
     "export/ExportWavDialog"
     "export/WavExporter"
 

--- a/src/export/ExportWavCommand.cpp
+++ b/src/export/ExportWavCommand.cpp
@@ -1,0 +1,501 @@
+
+#include "export/ExportWavCommand.hpp"
+
+#include "core/ChannelOutput.hpp"
+#include "core/Module.hpp"
+#include "core/ModuleFile.hpp"
+#include "export/WavExporter.hpp"
+
+#include <QByteArrayView>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QStringView>
+
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <optional>
+
+#ifdef _WIN32
+#include <io.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#include <unistd.h>
+#endif
+
+#define TU ExportWavCommandTU
+namespace TU {
+
+#define cmd_tr(str) QCoreApplication::translate("ExportWavCommand", str)
+
+// option names
+constexpr auto OPT_EXPORT     = "export-wav";
+constexpr auto OPT_CHANNELS   = "channels";
+constexpr auto OPT_SEPARATE   = "separate";
+constexpr auto OPT_PREFIX     = "prefix";
+constexpr auto OPT_LOOPS      = "loops";
+constexpr auto OPT_DURATION   = "duration";
+constexpr auto OPT_SAMPLERATE = "samplerate";
+constexpr auto OPT_SONG       = "song";
+
+// options that only make sense together with OPT_EXPORT
+constexpr std::array MODIFIERS = {
+    OPT_CHANNELS,
+    OPT_SEPARATE,
+    OPT_PREFIX,
+    OPT_LOOPS,
+    OPT_DURATION,
+    OPT_SAMPLERATE,
+    OPT_SONG
+};
+
+constexpr int DEFAULT_SAMPLERATE = 44100;
+
+void error(QString const& msg) {
+    fputs(qPrintable(cmd_tr("error: %1\n").arg(msg)), stderr);
+}
+
+void info(QString const& msg) {
+    fputs(qPrintable(msg), stderr);
+    fputc('\n', stderr);
+}
+
+//
+// Parses a channel list, ie "124" or "1,2,4". Commas and whitespace are
+// ignored. nullopt is returned for invalid input or if no channels were given.
+//
+std::optional<ChannelOutput::Flags> parseChannels(QString const& str) {
+    ChannelOutput::Flags flags = ChannelOutput::AllOff;
+    for (auto const ch : str) {
+        if (ch >= QChar('1') && ch <= QChar('4')) {
+            flags |= (ChannelOutput::Flag)(1 << (ch.unicode() - '1'));
+        } else if (ch != QChar(',') && !ch.isSpace()) {
+            return std::nullopt;
+        }
+    }
+
+    if (flags == ChannelOutput::AllOff) {
+        return std::nullopt;
+    }
+    return flags;
+}
+
+//
+// Parses a duration given in seconds ("90") or as minutes and seconds
+// ("01:30"). Zero and invalid input result in nullopt.
+//
+std::optional<std::chrono::seconds> parseDuration(QString const& str) {
+    bool ok = false;
+    unsigned seconds = 0;
+
+    auto const colon = str.indexOf(QChar(':'));
+    if (colon == -1) {
+        seconds = str.toUInt(&ok);
+    } else {
+        QStringView const view(str);
+        auto const mins = view.first(colon).toUInt(&ok);
+        if (ok) {
+            auto const secs = view.sliced(colon + 1).toUInt(&ok);
+            if (ok && secs < 60) {
+                seconds = mins * 60 + secs;
+            } else {
+                ok = false;
+            }
+        }
+    }
+
+    if (!ok || seconds == 0) {
+        return std::nullopt;
+    }
+    return std::chrono::seconds(seconds);
+}
+
+std::optional<int> parsePositiveInt(QString const& str) {
+    bool ok;
+    int const value = str.toInt(&ok);
+    if (!ok || value <= 0) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+QString invalidValue(char const* option, QString const& value) {
+    return cmd_tr("invalid value \"%1\" for --%2").arg(value, QLatin1String(option));
+}
+
+QString openError(ModuleFile const& file) {
+    switch (file.lastError()) {
+        case trackerboy::FormatError::invalidSignature:
+            return cmd_tr("the file is not a trackerboy module");
+        case trackerboy::FormatError::invalidRevision:
+            return cmd_tr("the module is from a newer version of Trackerboy");
+        case trackerboy::FormatError::cannotUpgrade:
+            return cmd_tr("failed to upgrade the module");
+        case trackerboy::FormatError::duplicateId:
+        case trackerboy::FormatError::invalid:
+        case trackerboy::FormatError::unknownChannel:
+            return cmd_tr("the module is corrupted");
+        default:
+            return cmd_tr("the file could not be read");
+    }
+}
+
+//
+// Prints export progress to stderr. When stderr is a terminal the percentage
+// of the current file is updated in place, otherwise each file is listed once.
+//
+class ProgressPrinter {
+
+public:
+    ProgressPrinter() :
+        mIsTerminal(isatty(fileno(stderr))),
+        mCurrent(),
+        mMax(1),
+        mLastPercent(-1)
+    {
+    }
+
+    void fileStarted(QString const& filename) {
+        finishCurrent();
+        mCurrent = filename;
+        mMax = 1;
+        mLastPercent = -1;
+        if (mIsTerminal) {
+            printPercent(0);
+        } else {
+            info(QStringLiteral("  %1").arg(filename));
+        }
+    }
+
+    void progressMax(int max) {
+        mMax = qMax(1, max);
+    }
+
+    void progress(int amount) {
+        if (mIsTerminal) {
+            auto const percent = qBound(0, amount * 100 / mMax, 100);
+            if (percent != mLastPercent) {
+                printPercent(percent);
+            }
+        }
+    }
+
+    //
+    // Marks the current file as complete
+    //
+    void finishCurrent() {
+        if (mIsTerminal && !mCurrent.isEmpty()) {
+            printPercent(100);
+            fputc('\n', stderr);
+            mCurrent.clear();
+        }
+    }
+
+    //
+    // Ends the in-place progress line, if any, without marking it complete
+    //
+    void abandonCurrent() {
+        if (mIsTerminal && !mCurrent.isEmpty()) {
+            fputc('\n', stderr);
+            mCurrent.clear();
+        }
+    }
+
+    QString const& current() const {
+        return mCurrent;
+    }
+
+private:
+    void printPercent(int percent) {
+        mLastPercent = percent;
+        fprintf(stderr, "\r  %s  %3d%%", qPrintable(mCurrent), percent);
+        fflush(stderr);
+    }
+
+    bool mIsTerminal;
+    QString mCurrent;
+    int mMax;
+    int mLastPercent;
+};
+
+}
+
+namespace ExportWavCommand {
+
+bool requested(int argc, char *argv[]) {
+    QByteArrayView const optionName(TU::OPT_EXPORT);
+
+    for (int i = 1; i < argc; ++i) {
+        QByteArrayView arg(argv[i]);
+        if (arg == QByteArrayView("--")) {
+            // everything after "--" is a positional argument
+            break;
+        }
+        if (!arg.startsWith('-')) {
+            continue;
+        }
+
+        // QCommandLineParser accepts long options with one or two dashes,
+        // with the value either separate or attached via '='
+        arg = arg.sliced(arg.startsWith(QByteArrayView("--")) ? 2 : 1);
+        auto const equals = arg.indexOf('=');
+        if (equals != -1) {
+            arg = arg.first(equals);
+        }
+
+        if (arg == optionName) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void addOptions(QCommandLineParser &parser) {
+    parser.addOptions({
+        {
+            QLatin1String(TU::OPT_EXPORT),
+            cmd_tr("Export the module to WAV and exit without starting the editor. "
+                   "<output> is the file to write, or the directory to write to "
+                   "when --separate is given."),
+            cmd_tr("output")
+        },
+        {
+            QLatin1String(TU::OPT_CHANNELS),
+            cmd_tr("Channels to export, as digits 1-4 (ie \"124\" or \"1,2,4\"). "
+                   "Default: all channels."),
+            cmd_tr("channels")
+        },
+        {
+            QLatin1String(TU::OPT_SEPARATE),
+            cmd_tr("Export each channel to its own file, named <prefix>.chN.wav, "
+                   "in the <output> directory.")
+        },
+        {
+            QLatin1String(TU::OPT_PREFIX),
+            cmd_tr("Filename prefix for --separate. Default: the module "
+                   "filename without its extension."),
+            cmd_tr("prefix")
+        },
+        {
+            QLatin1String(TU::OPT_LOOPS),
+            cmd_tr("Play the song <count> times. Default: 1. "
+                   "Cannot be combined with --duration."),
+            cmd_tr("count")
+        },
+        {
+            QLatin1String(TU::OPT_DURATION),
+            cmd_tr("Play for a fixed time, in seconds or mm:ss, instead of looping."),
+            cmd_tr("time")
+        },
+        {
+            QLatin1String(TU::OPT_SAMPLERATE),
+            cmd_tr("Samplerate of the exported audio, in Hz. Default: %1.")
+                .arg(TU::DEFAULT_SAMPLERATE),
+            cmd_tr("hz")
+        },
+        {
+            QLatin1String(TU::OPT_SONG),
+            cmd_tr("The song in the module to export, starting at 1. Default: 1."),
+            cmd_tr("number")
+        }
+    });
+}
+
+QString strayOption(QCommandLineParser const& parser) {
+    if (parser.isSet(QLatin1String(TU::OPT_EXPORT))) {
+        return {};
+    }
+
+    for (auto const option : TU::MODIFIERS) {
+        if (parser.isSet(QLatin1String(option))) {
+            return QLatin1String(option);
+        }
+    }
+
+    return {};
+}
+
+Status run(QCommandLineParser const& parser, QString const& modulePath) {
+
+    // Arguments ------------------------------------------------------------
+
+    if (modulePath.isEmpty()) {
+        TU::error(cmd_tr("a module file is required when exporting"));
+        return Status::badArguments;
+    }
+
+    auto const output = parser.value(QLatin1String(TU::OPT_EXPORT));
+
+    ChannelOutput::Flags channels = ChannelOutput::AllOn;
+    if (parser.isSet(QLatin1String(TU::OPT_CHANNELS))) {
+        auto const value = parser.value(QLatin1String(TU::OPT_CHANNELS));
+        auto const parsed = TU::parseChannels(value);
+        if (!parsed) {
+            TU::error(TU::invalidValue(TU::OPT_CHANNELS, value));
+            return Status::badArguments;
+        }
+        channels = *parsed;
+    }
+
+    trackerboy::Player::Duration duration = 1;
+    bool const hasLoops = parser.isSet(QLatin1String(TU::OPT_LOOPS));
+    bool const hasDuration = parser.isSet(QLatin1String(TU::OPT_DURATION));
+    if (hasLoops && hasDuration) {
+        TU::error(cmd_tr("--%1 and --%2 cannot be used together")
+                    .arg(QLatin1String(TU::OPT_LOOPS), QLatin1String(TU::OPT_DURATION)));
+        return Status::badArguments;
+    } else if (hasLoops) {
+        auto const value = parser.value(QLatin1String(TU::OPT_LOOPS));
+        auto const parsed = TU::parsePositiveInt(value);
+        if (!parsed) {
+            TU::error(TU::invalidValue(TU::OPT_LOOPS, value));
+            return Status::badArguments;
+        }
+        duration = *parsed;
+    } else if (hasDuration) {
+        auto const value = parser.value(QLatin1String(TU::OPT_DURATION));
+        auto const parsed = TU::parseDuration(value);
+        if (!parsed) {
+            TU::error(TU::invalidValue(TU::OPT_DURATION, value));
+            return Status::badArguments;
+        }
+        duration = *parsed;
+    }
+
+    int samplerate = TU::DEFAULT_SAMPLERATE;
+    if (parser.isSet(QLatin1String(TU::OPT_SAMPLERATE))) {
+        auto const value = parser.value(QLatin1String(TU::OPT_SAMPLERATE));
+        auto const parsed = TU::parsePositiveInt(value);
+        if (!parsed) {
+            TU::error(TU::invalidValue(TU::OPT_SAMPLERATE, value));
+            return Status::badArguments;
+        }
+        samplerate = *parsed;
+    }
+
+    int songNumber = 1;
+    if (parser.isSet(QLatin1String(TU::OPT_SONG))) {
+        auto const value = parser.value(QLatin1String(TU::OPT_SONG));
+        auto const parsed = TU::parsePositiveInt(value);
+        if (!parsed) {
+            TU::error(TU::invalidValue(TU::OPT_SONG, value));
+            return Status::badArguments;
+        }
+        songNumber = *parsed;
+    }
+
+    bool const separate = parser.isSet(QLatin1String(TU::OPT_SEPARATE));
+    bool const hasPrefix = parser.isSet(QLatin1String(TU::OPT_PREFIX));
+    QString prefix;
+    if (separate) {
+        if (hasPrefix) {
+            prefix = parser.value(QLatin1String(TU::OPT_PREFIX));
+        } else {
+            prefix = QFileInfo(modulePath).completeBaseName();
+        }
+        if (prefix.isEmpty()) {
+            TU::error(cmd_tr("--%1 cannot be empty").arg(QLatin1String(TU::OPT_PREFIX)));
+            return Status::badArguments;
+        }
+    } else if (hasPrefix) {
+        TU::error(cmd_tr("--%1 requires --%2")
+                    .arg(QLatin1String(TU::OPT_PREFIX), QLatin1String(TU::OPT_SEPARATE)));
+        return Status::badArguments;
+    }
+
+    // Module ---------------------------------------------------------------
+
+    QFileInfo const moduleInfo(modulePath);
+    if (!moduleInfo.exists()) {
+        TU::error(cmd_tr("module file \"%1\" does not exist").arg(modulePath));
+        return Status::failed;
+    }
+    if (!moduleInfo.isFile()) {
+        TU::error(cmd_tr("\"%1\" is not a file").arg(modulePath));
+        return Status::failed;
+    }
+
+    Module mod;
+    ModuleFile moduleFile;
+    if (!moduleFile.open(modulePath, mod)) {
+        TU::error(cmd_tr("could not open module: %1").arg(TU::openError(moduleFile)));
+        return Status::failed;
+    }
+
+    auto const songCount = mod.data().songs().size();
+    if (songNumber > songCount) {
+        TU::error(cmd_tr("cannot export song %1, the module only has %2 song(s)")
+                    .arg(songNumber)
+                    .arg(songCount));
+        return Status::badArguments;
+    }
+    mod.setSong(songNumber - 1);
+
+    // Destination ----------------------------------------------------------
+
+    if (separate) {
+        if (!QDir(output).mkpath(QStringLiteral("."))) {
+            TU::error(cmd_tr("could not create output directory \"%1\"").arg(output));
+            return Status::failed;
+        }
+    } else {
+        QFileInfo const outputInfo(output);
+        if (outputInfo.isDir()) {
+            TU::error(cmd_tr("\"%1\" is a directory (use --%2 to export files into a directory)")
+                        .arg(output, QLatin1String(TU::OPT_SEPARATE)));
+            return Status::badArguments;
+        }
+        if (!outputInfo.dir().exists()) {
+            TU::error(cmd_tr("output directory \"%1\" does not exist").arg(outputInfo.dir().path()));
+            return Status::failed;
+        }
+    }
+
+    // Export ---------------------------------------------------------------
+
+    TU::info(cmd_tr("Exporting %1, song %2# %3 (%4 Hz)")
+                .arg(moduleInfo.fileName())
+                .arg(songNumber)
+                .arg(QString::fromStdString(mod.song()->name()))
+                .arg(samplerate));
+
+    WavExporter exporter(mod, samplerate);
+    exporter.setDuration(duration);
+    exporter.setChannels(channels);
+    exporter.setSeparate(separate);
+    exporter.setDestination(output);
+    exporter.setSeparatePrefix(prefix);
+
+    // the exporter runs in its own thread and this thread blocks until it
+    // finishes, so these connections are direct: the slots are invoked from
+    // the exporter's thread, which is fine since they only write to stderr.
+    TU::ProgressPrinter printer;
+    QObject::connect(&exporter, &WavExporter::fileStarted,
+        [&printer](QString const& filename) { printer.fileStarted(filename); });
+    QObject::connect(&exporter, &WavExporter::progressMax,
+        [&printer](int max) { printer.progressMax(max); });
+    QObject::connect(&exporter, &WavExporter::progress,
+        [&printer](int amount) { printer.progress(amount); });
+
+    exporter.start();
+    exporter.wait();
+
+    if (exporter.failed()) {
+        auto const failedFile = printer.current().isEmpty() ? output : printer.current();
+        printer.abandonCurrent();
+        TU::error(cmd_tr("could not write \"%1\"").arg(failedFile));
+        return Status::failed;
+    }
+
+    printer.finishCurrent();
+    return Status::success;
+}
+
+}
+
+#undef cmd_tr
+#undef TU

--- a/src/export/ExportWavCommand.hpp
+++ b/src/export/ExportWavCommand.hpp
@@ -1,0 +1,49 @@
+
+#pragma once
+
+class QCommandLineParser;
+#include <QString>
+
+//
+// Command line front-end for WavExporter. Lets a module be exported to WAV
+// without starting the editor, for example:
+//
+//   trackerboy song.tbm --export-wav song.wav
+//   trackerboy song.tbm --export-wav out/ --separate --channels 1,2
+//
+// The GUI counterpart is ExportWavDialog.
+//
+namespace ExportWavCommand {
+
+    enum class Status {
+        success,        // export completed
+        badArguments,   // usage error: missing or invalid arguments
+        failed          // the module could not be loaded or the export failed
+    };
+
+    //
+    // Returns true if the export option is present in the raw program
+    // arguments. This is checked before a QApplication is constructed so that
+    // exporting does not require a display.
+    //
+    bool requested(int argc, char *argv[]);
+
+    //
+    // Adds the export options to the parser.
+    //
+    void addOptions(QCommandLineParser &parser);
+
+    //
+    // Returns the name of the first option that only applies to exporting
+    // and was set without the export option itself, or an empty string
+    // if there is no such option.
+    //
+    QString strayOption(QCommandLineParser const& parser);
+
+    //
+    // Runs the export using the parsed options. modulePath is the module file
+    // to export. Progress and errors are written to stderr.
+    //
+    Status run(QCommandLineParser const& parser, QString const& modulePath);
+
+}

--- a/src/export/WavExporter.cpp
+++ b/src/export/WavExporter.cpp
@@ -121,6 +121,7 @@ void WavExporter::run() {
         }
 
 
+        emit fileStarted(batches[i].filename);
         Wav wav(batches[i].filename.toStdString(), 2, mSamplerate);
         if (!wav.stream().good()) {
             mFailed = true;

--- a/src/export/WavExporter.hpp
+++ b/src/export/WavExporter.hpp
@@ -39,6 +39,10 @@ public:
     void cancel();
 
 signals:
+    //
+    // Emitted before writing to each output file, with its path
+    //
+    void fileStarted(QString const& filename);
     void progressMax(int max);
     void progress(int amount);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 
+#include "export/ExportWavCommand.hpp"
 #include "forms/MainWindow.hpp"
 
 #include <QApplication>
@@ -52,6 +53,7 @@ static std::string demangle(const char* name) {
 
 constexpr int EXIT_BAD_ARGUMENTS = -1;
 constexpr int EXIT_BAD_ALLOC = 1;
+constexpr int EXIT_EXPORT_FAILED = 2;
 
 //
 // Singleton class for a custom Qt message handler. This message handler wraps
@@ -127,7 +129,97 @@ public:
 
 
 
+#define main_tr(str) QCoreApplication::translate("main", str)
+
+//
+// Application-wide settings shared by the GUI and headless modes
+//
+static void setupApplication() {
+    QCoreApplication::setOrganizationName("Trackerboy");
+    QCoreApplication::setApplicationName("Trackerboy");
+    QCoreApplication::setApplicationVersion(VERSION_STR);
+    // use INI on all systems, much easier to edit by hand
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+}
+
+//
+// Sets up the command line parser. Shared by both modes so that --help
+// always lists every option.
+//
+static void setupParser(QCommandLineParser &parser) {
+    parser.setApplicationDescription(main_tr("Game Boy music tracker"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addPositionalArgument("[module_file]", main_tr("(Optional) the module file to open or export"));
+    ExportWavCommand::addOptions(parser);
+}
+
+//
+// Gets the module file positional argument, if given. false is returned
+// when too many arguments were given, after printing usage to stderr.
+//
+static bool getModuleArgument(QCommandLineParser const& parser, QString &moduleFile) {
+    auto const positionals = parser.positionalArguments();
+    switch (positionals.size()) {
+        case 0:
+            break;
+        case 1:
+            moduleFile = positionals[0];
+            break;
+        default:
+            // we could just only take the first argument and ignore the rest
+            // but I prefer to be strict
+            fputs("too many arguments given\n", stderr);
+            fputs(qPrintable(parser.helpText()), stderr);
+            return false;
+    }
+    return true;
+}
+
+//
+// Headless mode, for exporting a module from the command line. A
+// QCoreApplication is used instead of a QApplication so that no display
+// is required.
+//
+static int headlessMain(int argc, char *argv[]) {
+    QCoreApplication app(argc, argv);
+    setupApplication();
+
+    QCommandLineParser parser;
+    setupParser(parser);
+    parser.process(app);
+
+    QString moduleFile;
+    if (!getModuleArgument(parser, moduleFile)) {
+        return EXIT_BAD_ARGUMENTS;
+    }
+
+    ExportWavCommand::Status status;
+    try {
+        status = ExportWavCommand::run(parser, moduleFile);
+    } catch (const std::bad_alloc &) {
+        fputs("error: out of memory\n", stderr);
+        return EXIT_BAD_ALLOC;
+    } catch (const std::exception &except) {
+        fprintf(stderr, "error: %s\n", except.what());
+        return EXIT_EXPORT_FAILED;
+    }
+
+    switch (status) {
+        case ExportWavCommand::Status::success:
+            return EXIT_SUCCESS;
+        case ExportWavCommand::Status::badArguments:
+            return EXIT_BAD_ARGUMENTS;
+        default:
+            return EXIT_EXPORT_FAILED;
+    }
+}
+
 int main(int argc, char *argv[]) {
+
+    if (ExportWavCommand::requested(argc, argv)) {
+        return headlessMain(argc, argv);
+    }
 
     int code;
 
@@ -137,37 +229,25 @@ int main(int argc, char *argv[]) {
     #endif
 
     Application app(argc, argv);
-    QCoreApplication::setOrganizationName("Trackerboy");
-    QCoreApplication::setApplicationName("Trackerboy");
-    QCoreApplication::setApplicationVersion(VERSION_STR);
-    // use INI on all systems, much easier to edit by hand
-    QSettings::setDefaultFormat(QSettings::IniFormat);
-
-#define main_tr(str) QCoreApplication::translate("main", str)
+    setupApplication();
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(main_tr("Game Boy music tracker"));
-    parser.addHelpOption();
-    parser.addVersionOption();
-    parser.addPositionalArgument("[module_file]", main_tr("(Optional) the module file to open"));
-
+    setupParser(parser);
     parser.process(app);
 
     QString fileToOpen;
-    auto const positionals = parser.positionalArguments();
-    switch (positionals.size()) {
-        case 0:
-            break;
-        case 1:
-            fileToOpen = positionals[0];
-            break;
-        default:
-            // we could just only take the first argument and ignore the rest
-            // but I prefer to be strict
-            fputs("too many arguments given\n", stderr);
-            fputs(qPrintable(parser.helpText()), stderr);
+    if (!getModuleArgument(parser, fileToOpen)) {
+        return EXIT_BAD_ARGUMENTS;
+    }
 
+    {
+        // export-only options are meaningless without --export-wav
+        auto const stray = ExportWavCommand::strayOption(parser);
+        if (!stray.isEmpty()) {
+            fputs(qPrintable(main_tr("option --%1 can only be used when exporting\n").arg(stray)), stderr);
+            fputs(qPrintable(parser.helpText()), stderr);
             return EXIT_BAD_ARGUMENTS;
+        }
     }
 
     // register types for signals


### PR DESCRIPTION
Allows one to export tracker files to wav using the command line -- example invocation given below:

```sh
# export the whole song to a single file
trackerboy song.tbm --export-wav song.wav

# export channels 1, 2 and 4, each to its own file: out/song.ch1.wav, out/song.ch2.wav, ...
trackerboy song.tbm --export-wav out/ --separate --channels 1,2,4

# play the second song of the module 3 times, at 48000 Hz
trackerboy song.tbm --export-wav song.wav --song 2 --loops 3 --samplerate 48000

# play for 1 minute and 30 seconds instead of looping
trackerboy song.tbm --export-wav song.wav --duration 01:30
```

Found it useful when working on servers without a desktop environment.